### PR TITLE
Increment next element position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Release
 /project.tlb
 /.vs
 /*.opensdf
+/jN.vcxproj.user

--- a/common/Menu.cpp
+++ b/common/Menu.cpp
@@ -42,9 +42,8 @@ CMenuItem::CMenuItem(HMENU h, WORD id, ScriptObj* config):CAbstractMenuItem(){
 	MENUITEMINFO mii;
 	memset(&mii,0,sizeof(mii));
 	mii.cbSize = sizeof(mii);
-	mii.fMask = MIIM_DATA | MIIM_STRING | MIIM_ID;
+	mii.fMask = MIIM_DATA | MIIM_STRING;
 	mii.fType = MFT_STRING;
-	mii.wID = (UINT)m_Id_Handle;
 	mii.cch = SysStringLen(text);
 	mii.dwTypeData = text;
 
@@ -57,7 +56,6 @@ CMenuItem::CMenuItem(HMENU h, WORD id, ScriptObj* config):CAbstractMenuItem(){
 		TRUE,
 		&mii
 	);
-
 
 	SysFreeString(text);
 }
@@ -150,6 +148,19 @@ void CMenu::createMenu(HMENU parent, int position, TCHAR* text, HWND menuBarWind
 	res = SetMenuInfo(          
 		m_Id_Handle,
 		&mi
+	);
+
+
+	MENUITEMINFO mii;
+	mii.cbSize = sizeof(mii);
+	mii.fMask = MIIM_DATA;
+	mii.dwItemData = (ULONG_PTR)this;
+
+	res = SetMenuItemInfo(
+		m_ParentMenuHandle,
+		(UINT)m_Id_Handle,
+		FALSE,
+		&mii
 	);
 
 }

--- a/common/Menu.cpp
+++ b/common/Menu.cpp
@@ -205,6 +205,9 @@ HRESULT STDMETHODCALLTYPE CMenu::addMenu( VARIANT cfg, IMenu **result){
 		(*result)->put_text(&cfg.bstrVal);
 		(*result)->AddRef();
 	}
+
+	m_Items++;
+
 	return S_OK;
 }
 

--- a/common/Menu.h
+++ b/common/Menu.h
@@ -32,6 +32,31 @@ protected:
 	HMENU m_Id_Handle;
 	HMENU m_ParentMenuHandle;
 
+	UINT getOwnPosition() {
+		int count = GetMenuItemCount(m_ParentMenuHandle);
+		int result = count - 1;
+
+		MENUITEMINFO mii;
+		mii.cbSize = sizeof(mii);
+		mii.fMask = MIIM_DATA;
+
+		for (int i = 0; i < count; i++) {
+
+			BOOL res = GetMenuItemInfo(
+				m_ParentMenuHandle,
+				(UINT)i,
+				TRUE,
+				&mii
+			);
+
+			if (mii.dwItemData == (ULONG_PTR)this) {
+				return i;
+			}
+		}
+
+		throw "Menu item not found";
+	}
+
 	UINT  getMenuItemState(){
 		MENUITEMINFO mii;
 		mii.cbSize = sizeof(mii);
@@ -39,8 +64,8 @@ protected:
 
 		BOOL res = GetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 		if (!res){
@@ -79,8 +104,8 @@ public:
 		// get menu item length
 		BOOL res=GetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 
@@ -93,8 +118,8 @@ public:
 		// get menu item
 		res = GetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 
@@ -115,8 +140,8 @@ public:
 
 		BOOL res = SetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 
@@ -144,8 +169,8 @@ public:
 
 		BOOL res = SetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 
@@ -172,8 +197,8 @@ public:
 
 		BOOL res = SetMenuItemInfo(
 			m_ParentMenuHandle,
-			(UINT)m_Id_Handle,
-			FALSE,
+			getOwnPosition(),
+			TRUE,
 			&mii
 		);
 		
@@ -183,7 +208,7 @@ public:
 	virtual HRESULT STDMETHODCALLTYPE remove(){
 		CHECK_AND_FAIL;	// menu item is removed!
 
-		BOOL res = DeleteMenu(m_ParentMenuHandle,(UINT)m_Id_Handle, MF_BYCOMMAND);
+		BOOL res = DeleteMenu(m_ParentMenuHandle, getOwnPosition(), MF_BYPOSITION);
 		if (res){
 			m_Removed = TRUE;
 			Release(); // delete self reference

--- a/common/Menu.h
+++ b/common/Menu.h
@@ -29,7 +29,6 @@ template<class Interface>
 class CAbstractMenuItem : public CComDispatch<Interface>{
 protected:
 	BOOL m_Removed;
-	HMENU m_Id_Handle;
 	HMENU m_ParentMenuHandle;
 
 	UINT getOwnPosition() {
@@ -226,7 +225,7 @@ private:
 public:
 	static CMenuItem* GetInstance(HMENU hmenu, UINT itemPos);
 
-	CMenuItem(HMENU h, WORD id, ScriptObj* config);
+	CMenuItem(HMENU h, ScriptObj* config);
 
 	~CMenuItem();
 
@@ -239,8 +238,8 @@ protected:
 	ScriptObj* m_Config;
 
 private:
-	WORD  m_Items;
 	HWND m_Hwnd;
+	HMENU m_MenuHandle;
 
 public:
 	static CMenu* GetInstance(HMENU hmenu);


### PR DESCRIPTION
Separators and submenu elements are part of position calculations in parent menu. 
* Pure addressing with position in menu does not work when several items are removed in between
* Addressing with a command requires using of unique IDs which could collide with existing N++ IDs

This PR fixes inconsistency in position calculation in case of submenus and following to them menu items

Fix #117 