### PR TITLE
fix: indicator panel update (n++ optimization)

### DIFF
--- a/editor/view/EditorView.h
+++ b/editor/view/EditorView.h
@@ -61,8 +61,6 @@ public:
 private:
 
 	LRESULT getBufferId();
-	void setIndicatorLinesUpdater(int begin, int end);
-
 #pragma endregion
 
 

--- a/editor/view/IndicatorPanel.cpp
+++ b/editor/view/IndicatorPanel.cpp
@@ -20,31 +20,204 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "IndicatorPanel.h"
 
 #pragma warning (disable : 4355)
-IndicatorPanel::IndicatorPanel(SCIView* view ): m_IndicPixelsUp(this), m_IndicLinesUp(this)
+IndicatorPanel::IndicatorPanel(SCIView& view ): m_View(view), m_PixelsUpdateAction(*this, &IndicatorPanel::OnUpdatePixels), m_LinesUpdateAction(*this, &IndicatorPanel::OnUpdateLines)
 {
 	m_IndicatorMask = (~0); // All of indicators are enabled
 	m_Disabled = true;
-	m_View = view;
 
-	pixelIndicators = 0;
+	m_PixelIndicators = 0;
 
 	// let window calculate nc region again, to be able to draw panel first time
-	SetWindowPos(view->m_Handle, NULL,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+	SetWindowPos(view.m_Handle, NULL,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 }
 
 IndicatorPanel::~IndicatorPanel(void)
 {
-	ForegroundIdleHook::getInstance()->remove(&m_IndicLinesUp);
-	ForegroundIdleHook::getInstance()->remove(&m_IndicPixelsUp);
+	ForegroundIdleHook::getInstance()->remove(&m_LinesUpdateAction);
+	ForegroundIdleHook::getInstance()->remove(&m_PixelsUpdateAction);
 
-	if (pixelIndicators)
-		delete[] pixelIndicators;
+	if (m_PixelIndicators)
+		delete[] m_PixelIndicators;
+}
+
+void IndicatorPanel::updateLines(int begin, int end)
+{
+	// remove pixels updater when scheduled
+	ForegroundIdleHook::getInstance()->remove(&m_LinesUpdateAction);
+	ForegroundIdleHook::getInstance()->remove(&m_PixelsUpdateAction);
+
+	// shift m_Begin to the left when required
+	if (m_Begin > begin || (m_End == 0 /* first time */))
+		m_Begin = begin;
+
+	// shift m_End to the right when required
+	if (m_End != -1 && (end == -1 || m_End < end))
+		m_End = end;
+
+	// shedule lines update
+	ForegroundIdleHook::getInstance()->add(&m_LinesUpdateAction);
+}
+
+void IndicatorPanel::updatePixels()
+{
+	ForegroundIdleHook::getInstance()->remove(&m_PixelsUpdateAction);
+	ForegroundIdleHook::getInstance()->add(&m_PixelsUpdateAction);
+}
+
+void IndicatorPanel::OnUpdatePixels()
+{
+	if (m_Disabled)
+		return;
+
+	GetIndicatorPixels();
+	if (m_PixelIndicatorsLen > 0)
+		RedrawIndicatorPanel(); //m_View->paintIndicators();
+}
+
+void IndicatorPanel::OnUpdateLines()
+{
+	if (m_Disabled)
+		return;
+
+	if (GetIndicatorLines()) {
+		ForegroundIdleHook::getInstance()->add(&m_PixelsUpdateAction);
+		
+		// set to 0, to indicate finished update
+		m_Begin = 0; 
+		m_End = 0;
+	}
+	else {
+		ForegroundIdleHook::getInstance()->add(&m_LinesUpdateAction);
+	}
+}
+
+void IndicatorPanel::ClearIndicators(int begin, int end)
+{
+	if (m_Indicators.empty())
+		return;
+
+	// document line
+	unsigned int beginLine = (begin <= 0) ? 0 : m_View.sci(SCI_LINEFROMPOSITION, begin, 0);
+	unsigned int endLine = (end < 0) ? m_View.sci(SCI_GETLINECOUNT, 0, 0) : m_View.sci(SCI_LINEFROMPOSITION, end, 0);
+
+	// view line
+	auto beginViewPos = m_View.sci(SCI_VISIBLEFROMDOCLINE, beginLine, 0);
+	auto endViewPos = m_View.sci(SCI_VISIBLEFROMDOCLINE, endLine, 0);
+
+	if (end < 0)
+		endViewPos = max(endViewPos, m_Indicators.rbegin()->first);
+
+	m_Indicators.erase(
+		m_Indicators.emplace(beginViewPos, 0).first,
+		m_Indicators.emplace(endViewPos, 0).first
+	);
+}
+
+bool IndicatorPanel::GetIndicatorLines() {
+
+	auto stopTime = GetTickCount64() + 200; // 200ms
+
+	ClearIndicators(m_Begin, m_End);
+
+	if (m_Begin < 0)
+		m_Begin = 0;
+
+	if (m_End < 0)
+		m_End = m_View.sci(SCI_GETLENGTH, 0, 0);
+
+	auto line = m_View.sci(SCI_LINEFROMPOSITION, m_Begin, 0);
+	auto lineEnd = m_View.sci(SCI_GETLINEENDPOSITION, line, 0);
+	auto nextSavePosition = min(lineEnd, m_End - 1);
+
+	DWORD	mask = 0;
+
+	for (; m_Begin < m_End; ++m_Begin) {
+
+		// add indicator mask for the line to the list of masks
+		// if either end of line or end of update range is reached
+		if (m_Begin >= nextSavePosition) {
+
+			// dont add empty masks
+			if (mask) {
+				// get position of line in the view
+				auto viewPos = m_View.sci(SCI_VISIBLEFROMDOCLINE, line, 0);
+
+				if (viewPos >= 0) {
+					auto existingPos = m_Indicators.find(viewPos);
+					if (existingPos != m_Indicators.end())
+						existingPos->second = existingPos->second | mask;
+					else
+						m_Indicators.emplace(viewPos, mask);
+				}
+			}
+
+			line++;
+			lineEnd = m_View.sci(SCI_GETLINEENDPOSITION, line, 0);
+			nextSavePosition = min(lineEnd, m_End - 1);
+
+			mask = 0;
+
+			if (GetTickCount64() > stopTime)
+				return false;
+		}
+		//
+		DWORD tmp = static_cast<DWORD>(m_View.sci(SCI_INDICATORALLONFOR, m_Begin, 0));
+		mask = mask | tmp;
+	}
+
+	return true;
+}
+
+void IndicatorPanel::GetIndicatorPixels() {
+	m_PixelIndicatorsLen = (m_PanelRect.bottom - m_PanelRect.top);
+
+	int indicatorThickness = ((m_PanelRect.right - m_PanelRect.left) + 1) / 2;
+
+	if (m_PixelIndicators) {
+		delete[] m_PixelIndicators;
+		m_PixelIndicators = NULL;
+	}
+
+	int scrollHHeight = GetSystemMetrics(SM_CYHSCROLL);
+	if (hasStyle(m_View.m_Handle, WS_VSCROLL))
+		m_PixelIndicatorsLen -= 2 * scrollHHeight;
+	if (hasStyle(m_View.m_Handle, WS_HSCROLL))
+		m_PixelIndicatorsLen -= scrollHHeight;
+
+	if (m_PixelIndicatorsLen <= 0)
+		return; // not sufficient place
+
+	auto lines = m_View.sci(SCI_GETLINECOUNT, 0, 0);
+
+	auto lineHeight = m_View.sci(SCI_TEXTHEIGHT, 0, 0);
+
+	if (!(lineHeight && lines))
+		return; // avoid division by 0
+
+	auto visibleLines = m_View.sci(SCI_VISIBLEFROMDOCLINE, lines - 1, 0) + 1;
+	auto linesOnPage = (m_PixelIndicatorsLen) / lineHeight;
+
+	// maximum pixel per line on panel line height
+	float pixelPerLineOnPanel = (linesOnPage > visibleLines) ? lineHeight : (float)(m_PixelIndicatorsLen - indicatorThickness) / visibleLines;
+
+	m_PixelIndicators = new DWORD[m_PixelIndicatorsLen];
+
+	memset(m_PixelIndicators, 0, sizeof(DWORD) * m_PixelIndicatorsLen);
+
+	// setup mask
+	for (auto it = m_Indicators.begin(); it != m_Indicators.end(); ++it) {
+		int y = (int)(pixelPerLineOnPanel * (float)(it->first));
+
+		for (int t = y; t < (y + indicatorThickness) && t < m_PixelIndicatorsLen; t++) {
+			m_PixelIndicators[t] |= it->second;
+		}
+	}
 }
 
 void IndicatorPanel::RedrawIndicatorPanel(){
 	BOOL res;
 	res = 0;
-	res = RedrawWindow(m_View->m_Handle, &m_PanelRect, NULL, RDW_INVALIDATE | RDW_FRAME);
+	res = RedrawWindow(m_View.m_Handle, &m_PanelRect, NULL, RDW_INVALIDATE | RDW_FRAME);
 	res = res;
 };
 
@@ -72,15 +245,15 @@ LRESULT IndicatorPanel::OnNCCalcSize(HWND hwnd, UINT message, WPARAM wParam, LPA
 		m_UnderScroll.top		= m_UnderScroll.bottom	- hScrollHeight;
 		m_UnderScroll.left		= m_UnderScroll.right	- vScrollWidth;
 
-		ForegroundIdleHook::getInstance()->add( &m_IndicPixelsUp);
+		ForegroundIdleHook::getInstance()->add( &m_PixelsUpdateAction);
 	}
-	return m_View->CallOldWndProc(message,wParam,lParam);
+	return m_View.CallOldWndProc(message,wParam,lParam);
 }
 
 LRESULT IndicatorPanel::OnNCPaint(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam){
 
 	if (m_Disabled)
-		return m_View->CallOldWndProc(message,wParam,lParam);
+		return m_View.CallOldWndProc(message,wParam,lParam);
 
 	int borderWidth		= GetSystemMetrics(SM_CXFOCUSBORDER);
 	int scrollWidth		= GetSystemMetrics(SM_CXVSCROLL);
@@ -115,7 +288,7 @@ LRESULT IndicatorPanel::OnNCPaint(HWND hwnd, UINT message, WPARAM wParam, LPARAM
 		res = FillRgn(hdc, prRG, hbr3DFace);
 	}
 
-	if (pixelIndicators){
+	if (m_PixelIndicators){
 		paintIndicators(hdc);
 	}
 
@@ -123,166 +296,23 @@ LRESULT IndicatorPanel::OnNCPaint(HWND hwnd, UINT message, WPARAM wParam, LPARAM
 
 	ReleaseDC(hwnd, hdc);
 
-	return m_View->CallOldWndProc(message,wParam,lParam);
+	return m_View.CallOldWndProc(message,wParam,lParam);
 }
-
-void IndicatorPanel::ClearIndicators(int begin, int end){
-	if (begin <= 0 && end < 0)
-		m_Indicators.clear();
-
-	// document line
-	unsigned int beginLine	= (begin <= 0)? 0 : m_View->sci(SCI_LINEFROMPOSITION, begin, 0);
-	unsigned int endLine	= (end < 0)? m_View->sci(SCI_GETLINECOUNT, 0, 0) : m_View->sci(SCI_LINEFROMPOSITION, end, 0);
-
-	// view line
-	beginLine	= m_View->sci(SCI_VISIBLEFROMDOCLINE, beginLine, 0);
-	endLine		= m_View->sci(SCI_VISIBLEFROMDOCLINE, endLine, 0);
-
-	// walk backwards
-	for(int i=m_Indicators.size()-1; i >=0  ; i--){
-		LineMask& lm = m_Indicators[i];
-		if (beginLine > lm.line || endLine < lm.line)
-			continue;
-
-		m_Indicators.erase(m_Indicators.begin() + i);
-	}
-}
-
-void IndicatorPanel::GetIndicatorLines(int begin, int end){ 
-	ClearIndicators(begin, end);
-
-	if (begin < 0)
-		begin = 0;
-
-
-	if (end < 0)
-		end = m_View->sci(SCI_GETLENGTH, 0, 0);
-	
-	DWORD	mask = 0;
-
-	int line = m_View->sci(SCI_LINEFROMPOSITION, begin, 0);
-	int lineEnd = m_View->sci(SCI_GETLINEENDPOSITION, line, 0);
-
-	for (int p=begin; p < end; p++){
-
-		// move indicator mask for line into the list of masks
-		// if end of line or end of file
-		if (lineEnd <= p || p == end-1){ // new line
-
-			// dont save empty masks
-			if (mask){ // save mask from last line
-
-				// get position of line in the view
-				DWORD viewPos = m_View->sci(SCI_VISIBLEFROMDOCLINE, line, 0);
-				if (viewPos >= 0){
-					LineMask lm = {viewPos, mask};
-					m_Indicators.push_back(lm);
-				}
-			}
-
-			line++;
-			lineEnd = m_View->sci(SCI_GETLINEENDPOSITION, line, 0);
-
-			mask = 0;
-		}
-		//
-		DWORD tmp = m_View->sci(SCI_INDICATORALLONFOR, p, 0); 	
-		mask = mask | tmp;
-	}
-}
-
-void IndicatorPanel::GetIndicatorPixels(){
-	m_PixelIndicatorsLen = (m_PanelRect.bottom - m_PanelRect.top);
-
-	int indicatorThickness = ((m_PanelRect.right - m_PanelRect.left) + 1)/ 2;
-
-	if (pixelIndicators){
-		delete[] pixelIndicators;
-		pixelIndicators = NULL;
-	}
-
-	int scrollHHeight	= GetSystemMetrics(SM_CYHSCROLL);
-	if (hasStyle(m_View->m_Handle, WS_VSCROLL))
-		m_PixelIndicatorsLen -= 2*scrollHHeight;
-	if (hasStyle(m_View->m_Handle, WS_HSCROLL))
-		m_PixelIndicatorsLen -= scrollHHeight;
-
-	if (m_PixelIndicatorsLen <= 0)
-		return; // not sufficient place
-
-	int lines = m_View->sci(SCI_GETLINECOUNT, 0,0);
-
-	int lineHeight = m_View->sci(SCI_TEXTHEIGHT, 0, 0);
-
-	if (!(lineHeight && lines))
-		return; // avoid division by 0
-	
-	int visibleLines = m_View->sci(SCI_VISIBLEFROMDOCLINE, lines-1, 0)+1;
-	int linesOnPage = (m_PixelIndicatorsLen) / lineHeight;
-
-	// maximum pixel per line on panel line height
-	float pixelPerLineOnPanel = (linesOnPage > visibleLines)? lineHeight : (float)(m_PixelIndicatorsLen - indicatorThickness)/ visibleLines; 
-
-	pixelIndicators = new DWORD[m_PixelIndicatorsLen];
-
-	memset(pixelIndicators, 0, sizeof(DWORD) * m_PixelIndicatorsLen);
-
-	// setup mask
-	for(int l=0, c=m_Indicators.size(); l < c; l++){
-		LineMask& lm = m_Indicators[l];
-		int y = (int)(pixelPerLineOnPanel * (float)(lm.line));
-				
-		for (int t = y; t < (y + indicatorThickness) && t < m_PixelIndicatorsLen; t++) {
-			pixelIndicators[t] |= lm.mask;
-		}
-	}
-
-	//// distribute mask to other pixels if possible
-	//for(int l=0; l < m_PixelIndicatorsLen; l++){
-	//	DWORD pi = pixelIndicators[l];
-	//			
-	//	int next = l + indicatorThickness;
-	//	DWORD indicator = 0x1;
-	//	// if pi contains bits and next pixel does not have bits
-	//	while(pi && next < m_PixelIndicatorsLen && !pixelIndicators[next]){
-	//				
-	//		// seek to next present indicator
-	//		while(!(pi & indicator)){
-	//			indicator = indicator << 1;
-	//		}
-
-	//		// substract indicator from pi
-	//		pi = pi & ~indicator;
-	//				
-	//		// set indicator at the current position and 
-	//		// move other indicators to the next pixel
-	//		pixelIndicators[l] = indicator;
-	//		pixelIndicators[next] = pi;
-
-	//		l += 1;
-	//		next += 1;
-
-	//		// seek indicator
-	//		indicator = indicator << 1;
-	//	}
-	//}
-}
-
 
 void IndicatorPanel::paintIndicators(){
-	HDC hdc = GetWindowDC(m_View->m_Handle);
+	HDC hdc = GetWindowDC(m_View.m_Handle);
 
 	paintIndicators(hdc);
 
-	ReleaseDC(m_View->m_Handle, hdc);
+	ReleaseDC(m_View.m_Handle, hdc);
 }
 
 void IndicatorPanel::paintIndicators(HDC hdc){
 	
-	if (!pixelIndicators || m_Disabled)
+	if (!m_PixelIndicators || m_Disabled)
 		return;
 
-	bool vscroll = hasStyle(m_View->m_Handle, WS_VSCROLL);
+	bool vscroll = hasStyle(m_View.m_Handle, WS_VSCROLL);
 	int scrollHHeight	= GetSystemMetrics(SM_CXHSCROLL);
 	HBRUSH hbr3DFace = (HBRUSH)GetSysColorBrush(COLOR_3DFACE); 
 	
@@ -295,7 +325,7 @@ void IndicatorPanel::paintIndicators(HDC hdc){
 	int indicatorRightPos = m_PanelRect.right - indicatorPadding;
 
 	for (int i=0; i<m_PixelIndicatorsLen; i++){
-		DWORD mask = pixelIndicators[i];
+		DWORD mask = m_PixelIndicators[i];
 		DWORD maskToPaint = m_IndicatorMask & mask;
 		if (maskToPaint){
 			COLORREF color = getColorForMask(maskToPaint);		
@@ -322,7 +352,7 @@ COLORREF IndicatorPanel::getColorForMask(DWORD mask){
 
 	while(mask){
 		if (mask & 0x1){
-			COLORREF c = m_View->sci(SCI_INDICGETFORE, indic, 0);
+			COLORREF c = static_cast<COLORREF>(m_View.sci(SCI_INDICGETFORE, indic, 0));
 			r += GetRValue(c);
 			g += GetGValue(c);
 			b += GetBValue(c);
@@ -344,7 +374,7 @@ void IndicatorPanel::SetDisabled(bool value){
 	m_Disabled = value;
 
 	// let window calculate nc region again, to be able to draw panel first time
-	SetWindowPos(m_View->m_Handle, NULL,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+	SetWindowPos(m_View.m_Handle, NULL,0,0,0,0,SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
 }
 
 bool IndicatorPanel::GetDisabled(){

--- a/jN.vcxproj
+++ b/jN.vcxproj
@@ -26,6 +26,7 @@
     <VersionMinor>0</VersionMinor>
     <BuildNumber>0</BuildNumber>
     <VersionRevision>0</VersionRevision>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
@@ -41,7 +42,7 @@
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <PlatformToolset>v142</PlatformToolset>


### PR DESCRIPTION
The newest version of N++ updates indicators only for visible area in the view and not for all existing lines of the document. The smart highlighter used to use this information to update the indicator panel.

The user needs either scroll through entire document to force an update of the entire indicator panel or switch from one document to another and back.

This PR handles the N++ smart highlighter messages as if the entire document needs an indicators update.

Closes #125